### PR TITLE
Speed up query evaluation, pagination, and index writes.

### DIFF
--- a/example/core/lab.py
+++ b/example/core/lab.py
@@ -34,7 +34,7 @@ from .documents import (
     VendorDocument,
 )
 from .models import Product
-from .views import catalog_queryset, query_data
+from .views import _unfiltered, catalog_queryset, query_data
 
 
 @dataclass
@@ -847,12 +847,12 @@ class AsyncSearchView(SearchDebugMixin, SearchListViewMixin, ListView):
         return await self.aget(request, *args, **kwargs)
 
     async def afacets(self) -> dict[str, list[dict[str, Any]]]:
-        return await self.get_search_queryset().afacets(
+        return await self.get_queryset().afacets(
             "category__name", "tags__name", "vendor__name"
         )
 
     async def aget_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        qs = self.get_search_queryset()
+        qs = self.get_queryset()
         raw_query, raw_params = qs.raw()
         data = query_data(self.request)
         context = await super().aget_context_data(query_data=data, **kwargs)
@@ -863,7 +863,11 @@ class AsyncSearchView(SearchDebugMixin, SearchListViewMixin, ListView):
         context["explain"] = await qs.aexplain()
         hidden = Product.objects.filter(available=False)
         context["sqlite_hidden"] = await hidden.acount()
-        context["redis_count"] = await ProductDocument.objects.all().acount()
+        paginator = context.get("paginator")
+        if _unfiltered(qs) and paginator is not None:
+            context["redis_count"] = paginator.count
+        else:
+            context["redis_count"] = await ProductDocument.objects.all().acount()
         context["price_stats"] = await qs.aaggregate(
             Aggregate()
             .group_by("available")

--- a/example/core/views.py
+++ b/example/core/views.py
@@ -116,6 +116,15 @@ def catalog_queryset(request: HttpRequest) -> Any:
     return qs
 
 
+def _unfiltered(qs: Any) -> bool:
+    return (
+        not getattr(qs, "_none", False)
+        and not getattr(qs, "_extra", None)
+        and not getattr(qs, "_knn", None)
+        and not getattr(getattr(qs, "_q", None), "children", True)
+    )
+
+
 def _cast_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     out = []
     for row in rows:
@@ -147,12 +156,12 @@ class SearchView(SearchDebugMixin, SearchListViewMixin, ListView):
         return super().get(request, *args, **kwargs)
 
     def facets(self) -> dict[str, list[dict[str, Any]]]:
-        return self.get_search_queryset().facets(
+        return self.get_queryset().facets(
             "category__name", "tags__name", "vendor__name"
         )
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        qs = self.get_search_queryset()
+        qs = self.get_queryset()
         raw_query, raw_params = qs.raw()
         data = query_data(self.request)
         context = super().get_context_data(query_data=data, **kwargs)
@@ -180,7 +189,11 @@ class SearchView(SearchDebugMixin, SearchListViewMixin, ListView):
         context["raw_params"] = display_params(raw_params)
         context["explain"] = qs.explain()
         context["sqlite_hidden"] = Product.objects.filter(available=False).count()
-        context["redis_count"] = ProductDocument.objects.all().count()
+        paginator = context.get("paginator")
+        if _unfiltered(qs) and paginator is not None:
+            context["redis_count"] = paginator.count
+        else:
+            context["redis_count"] = ProductDocument.objects.all().count()
         return context
 
 

--- a/redis_search_django/documents.py
+++ b/redis_search_django/documents.py
@@ -25,6 +25,9 @@ class RelatedConfig(TypedDict):
     many: bool
 
 
+_MANAGER_ATTR = "_rsd_manager"
+
+
 class DocumentOptions:
     """Resolved Django + Index options for a Document class."""
 
@@ -353,9 +356,14 @@ def _attach_exception_classes(cls: type[Document]) -> None:
 
 class _ObjectsDescriptor:
     def __get__(self, obj: Document | None, owner: type[Document]) -> DocumentManager:
+        cached = owner.__dict__.get(_MANAGER_ATTR)
+        if cached is not None:
+            return cached  # type: ignore[no-any-return]
         from .query.queryset import DocumentManager
 
-        return DocumentManager(owner)
+        manager = DocumentManager(owner)
+        setattr(owner, _MANAGER_ATTR, manager)
+        return manager
 
 
 class Document(metaclass=DocumentMeta):

--- a/redis_search_django/fields.py
+++ b/redis_search_django/fields.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import datetime
 import struct
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from decimal import Decimal
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 from uuid import UUID
 
 from django.db import models
@@ -19,15 +19,16 @@ from redis.commands.search.field import VectorField as RedisVectorField
 from .embeddings import (
     Embedder,
     EmbedFn,
+    _as_numeric_list,
     as_floats,
     call_embed,
-    is_vector,
     resolve_embedder,
     resolve_source,
 )
 from .enums import Storage
 from .exceptions import ConfigurationError
 from .types import (
+    FieldInput,
     IndexValue,
     Named,
     is_prepare_hook,
@@ -35,6 +36,8 @@ from .types import (
 
 if TYPE_CHECKING:
     from .documents import Document
+
+_UNSET = object()
 
 
 class Field:
@@ -62,19 +65,32 @@ class Field:
         self.no_stem = no_stem
         self.phonetic = phonetic
         self.document_cls: type[Document] | None = None
+        self._prepare_hook: Callable[[models.Model], object] | object | None = _UNSET
 
     def bind(self, name: str, document_cls: type[Document]) -> None:
         self.name = name
         self.document_cls = document_cls
         if self.model_attr is None:
             self.model_attr = name
+        self._prepare_hook = _UNSET
 
     def copy(self) -> Field:
         """Shallow copy so subclasses do not mutate a shared base Field."""
         clone = self.__class__.__new__(self.__class__)
         clone.__dict__.update(self.__dict__)
         clone.document_cls = None
+        clone._prepare_hook = _UNSET
         return clone
+
+    def _resolved_prepare(
+        self, document_cls: type[Document]
+    ) -> Callable[[models.Model], object] | None:
+        hook = self._prepare_hook
+        if hook is _UNSET:
+            found = getattr(document_cls, f"prepare_{self.name}", None)
+            hook = found if is_prepare_hook(found) else None
+            self._prepare_hook = hook
+        return hook  # type: ignore[return-value]
 
     def redis_type(self) -> str:
         raise NotImplementedError
@@ -107,10 +123,10 @@ class Field:
         return str(raw)
 
     def prepare(self, instance: models.Model, document_cls: type[Document]) -> object:
+        hook = self._resolved_prepare(document_cls)
+        if hook is not None:
+            return hook(instance)
         assert self.name is not None
-        prepare = getattr(document_cls, f"prepare_{self.name}", None)
-        if is_prepare_hook(prepare):
-            return prepare(instance)
         return _resolve_attr(instance, self.model_attr or self.name)
 
 
@@ -321,6 +337,8 @@ class Vector(Field):
         self.initial_cap = initial_cap
         self.source = source
         self.embedder = embedder
+        code = "f" if self.vector_type == "FLOAT32" else "d"
+        self._struct_fmt = f"<{self.dims}{code}"
 
     def redis_type(self) -> str:
         return "VECTOR"
@@ -343,7 +361,7 @@ class Vector(Field):
         self, instance: models.Model, document_cls: type[Document]
     ) -> list[float] | None:
         assert self.name is not None
-        hook = getattr(document_cls, f"prepare_{self.name}", None)
+        hook = self._resolved_prepare(document_cls)
         if hook is not None:
             raw = hook(instance)
         else:
@@ -355,8 +373,17 @@ class Vector(Field):
             )
         if raw is None:
             return None
-        if is_vector(raw):
-            return as_floats(raw, field_name=self.name, dims=self.dims)
+        try:
+            values = _as_numeric_list(raw)
+        except (TypeError, ValueError):
+            values = None
+        if values is not None:
+            if len(values) != self.dims:
+                raise ConfigurationError(
+                    f"Vector field {self.name!r} expected {self.dims} dimensions, "
+                    f"got {len(values)}."
+                )
+            return values
         embedder = resolve_embedder(document_cls, self)
         if embedder is None:
             raise ConfigurationError(
@@ -366,7 +393,9 @@ class Vector(Field):
                 f"from prepare_{self.name}()."
             )
         return as_floats(
-            call_embed(embedder, raw), field_name=self.name, dims=self.dims
+            call_embed(embedder, cast(FieldInput, raw)),
+            field_name=self.name,
+            dims=self.dims,
         )
 
     def to_index_value(self, raw: object, *, storage: str = "json") -> IndexValue:
@@ -396,8 +425,7 @@ class Vector(Field):
         return [float(item) for item in struct.unpack(self._struct_format(), blob)]
 
     def _struct_format(self) -> str:
-        code = "f" if self.vector_type == "FLOAT32" else "d"
-        return f"<{self.dims}{code}"
+        return self._struct_fmt
 
 
 class Object(Field):

--- a/redis_search_django/indexer.py
+++ b/redis_search_django/indexer.py
@@ -173,6 +173,8 @@ class Indexer:
         resolved = (
             tuple(prefixes) if prefixes is not None else write_prefixes(document_cls)
         )
+        json_path = Path.root_path()
+        store_json = document_cls._meta.storage is Storage.JSON
         # QuerySet.iterator() ignores prefetch_related (N+1 on Nested fields).
         for instance in _iter_records(qs, chunk):
             prepared = self._prepare_write(document_cls, instance)
@@ -183,15 +185,15 @@ class Indexer:
                 pending += len(keys)
             else:
                 _pk, payload = prepared
-                mapping = None
-                if document_cls._meta.storage is not Storage.JSON:
-                    mapping = self.serializer.flatten_hash(document_cls, payload)
-                for key in keys:
-                    if document_cls._meta.storage is Storage.JSON:
-                        json_set(pipe, key, payload, path=Path.root_path())
-                    else:
-                        assert mapping is not None
-                        pipe.hset(key, mapping=hash_fields(mapping))
+                if store_json:
+                    for key in keys:
+                        json_set(pipe, key, payload, path=json_path)
+                else:
+                    mapping = hash_fields(
+                        self.serializer.flatten_hash(document_cls, payload)
+                    )
+                    for key in keys:
+                        pipe.hset(key, mapping=mapping)
                 pending += len(keys)
             count += 1
             if pending >= chunk:
@@ -224,6 +226,8 @@ class Indexer:
         resolved = (
             tuple(prefixes) if prefixes is not None else write_prefixes(document_cls)
         )
+        json_path = Path.root_path()
+        store_json = document_cls._meta.storage is Storage.JSON
         async for instance in _aiter_records(qs, chunk):
             prepared = await sync_to_async(self._prepare_write)(document_cls, instance)
             keys = self._keys_for(document_cls, instance.pk, resolved)
@@ -233,15 +237,17 @@ class Indexer:
                 pending += len(keys)
             else:
                 _pk, payload = prepared
-                if document_cls._meta.storage is Storage.JSON:
+                if store_json:
                     for key in keys:
-                        json_set(pipe, key, payload, path=Path.root_path())
+                        json_set(pipe, key, payload, path=json_path)
                 else:
-                    mapping = await sync_to_async(self.serializer.flatten_hash)(
-                        document_cls, payload
+                    mapping = hash_fields(
+                        await sync_to_async(self.serializer.flatten_hash)(
+                            document_cls, payload
+                        )
                     )
                     for key in keys:
-                        pipe.hset(key, mapping=hash_fields(mapping))
+                        pipe.hset(key, mapping=mapping)
                 pending += len(keys)
             count += 1
             if pending >= chunk:

--- a/redis_search_django/query/aggregate.py
+++ b/redis_search_django/query/aggregate.py
@@ -17,7 +17,7 @@ from ..redis import (
 )
 from ..schema import flatten_lookup
 from ..types import IndexValue, RedisAggregateResult
-from .compiler import QueryCompiler, QueryParams, ensure_query_params
+from .compiler import QueryParams, ensure_query_params
 from .instrument import observe, query_text
 
 if TYPE_CHECKING:
@@ -81,14 +81,15 @@ def _build_aggregate(
     query_params: QueryParams | None = None,
 ) -> tuple[type[Document], AggregateRequest, QueryParams | None]:
     document_cls = queryset.document_cls
-    compiled = QueryCompiler(document_cls).compile(queryset._q)
-    query = queryset._extra or compiled.query
+    if queryset._compiled is None:
+        queryset._filter_query()
+    compiled = queryset._compiled
+    assert compiled is not None
+    query, compiled_params = compiled
     if query_params is not None:
         params = query_params or None
-    elif queryset._extra is not None:
-        params = queryset._extra_params or None
     else:
-        params = compiled.params or None
+        params = compiled_params
 
     if isinstance(spec, AggregateRequest):
         request = spec

--- a/redis_search_django/query/compiler.py
+++ b/redis_search_django/query/compiler.py
@@ -20,6 +20,7 @@ from .lookups import Q, split_lookup
 MAX_QUERY_BYTES = 32 * 1024
 _PARAM_REF = re.compile(r"\$(?P<name>[A-Za-z][A-Za-z0-9_]*)")
 
+
 QueryParamValue = str | bytes | int | float
 QueryParams = dict[str, QueryParamValue]
 

--- a/redis_search_django/query/instrument.py
+++ b/redis_search_django/query/instrument.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Generator
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from time import perf_counter
@@ -116,6 +116,7 @@ def _stacktraces_enabled() -> bool:
 _listener: ContextVar[QueryListener | None] = ContextVar(
     "redis_search_query_listener", default=None
 )
+NOOP_OBSERVE = nullcontext(None)
 
 
 @dataclass(slots=True)
@@ -191,6 +192,8 @@ def observe_write(
     params: dict[str, Any] | None = None,
 ) -> Any:
     """Time a JSON.SET / HSET / DEL when a listener is installed."""
+    if current_listener() is None:
+        return NOOP_OBSERVE
     meta = getattr(document_cls, "_meta", None)
     return observe(
         kind="delete" if command == "DEL" else "write",
@@ -205,6 +208,8 @@ def observe_write(
 
 def observe_pipeline(document_cls: Any, count: int) -> Any:
     """Time one pipeline ``execute()`` of index writes."""
+    if current_listener() is None:
+        return NOOP_OBSERVE
     meta = getattr(document_cls, "_meta", None)
     return observe(
         kind="write",

--- a/redis_search_django/query/queryset.py
+++ b/redis_search_django/query/queryset.py
@@ -40,7 +40,7 @@ from ..types import (
 )
 from ..versioning import public_payload
 from .compiler import QueryCompiler, QueryParams, ensure_query_params
-from .instrument import observe, query_text
+from .instrument import NOOP_OBSERVE, current_listener, observe, query_text
 from .knn import KnnClause, validate_score_name, wrap_knn_query
 from .lookups import Q
 from .results import SearchHit, SearchResult
@@ -57,6 +57,9 @@ class _SearchPage(Protocol):
 
 
 logger = logging.getLogger("redis_search_django")
+_TEXT_LOOKUPS_ATTR = "_rsd_text_lookups"
+_HASH_VECTORS_ATTR = "_rsd_hash_vectors"
+_HAS_VECTOR_ATTR = "_rsd_has_vector"
 
 
 class DocumentManager:
@@ -225,6 +228,8 @@ class DocumentQuerySet:
         self._none = False
         self._knn: KnnClause | None = None
         self._result: SearchResult | None = None
+        self._compiled: tuple[str, QueryParams | None] | None = None
+        self._total: int | None = None
 
     def _clone(self) -> DocumentQuerySet:
         clone = DocumentQuerySet(self.document_cls)
@@ -426,18 +431,36 @@ class DocumentQuerySet:
     def count(self) -> int:
         if self._knn is not None:
             return len(self._search(offset=0, limit=self._knn.k, content=False).hits)
-        return self._search(offset=0, limit=0).total
+        if self._result is not None:
+            return self._result.total
+        if self._total is not None:
+            return self._total
+        self._total = self._search(offset=0, limit=0).total
+        return self._total
 
     async def acount(self) -> int:
         if self._knn is not None:
             result = await self._asearch(offset=0, limit=self._knn.k, content=False)
             return len(result.hits)
-        return (await self._asearch(offset=0, limit=0)).total
+        if self._result is not None:
+            return self._result.total
+        if self._total is not None:
+            return self._total
+        self._total = (await self._asearch(offset=0, limit=0)).total
+        return self._total
 
     def exists(self) -> bool:
+        if self._result is not None:
+            return self._result.total > 0
+        if self._total is not None:
+            return self._total > 0
         return self._search(offset=0, limit=1).total > 0
 
     async def aexists(self) -> bool:
+        if self._result is not None:
+            return self._result.total > 0
+        if self._total is not None:
+            return self._total > 0
         return (await self._asearch(offset=0, limit=1)).total > 0
 
     def __bool__(self) -> bool:
@@ -616,13 +639,18 @@ class DocumentQuerySet:
         return SearchResult(hits=hits, total=total, document_cls=self.document_cls)
 
     def _filter_query(self) -> tuple[str, QueryParams | None]:
-        if self._extra is not None:
-            query = self._extra
-            params: QueryParams | None = self._extra_params or None
+        compiled = self._compiled
+        if compiled is None:
+            if self._extra is not None:
+                query = self._extra
+                params: QueryParams | None = self._extra_params or None
+            else:
+                built = QueryCompiler(self.document_cls).compile(self._q)
+                query = built.query
+                params = built.params or None
+            self._compiled = (query, params)
         else:
-            compiled = QueryCompiler(self.document_cls).compile(self._q)
-            query = compiled.query
-            params = compiled.params or None
+            query, params = compiled
         if self._knn is not None:
             query, params = wrap_knn_query(query, self._knn, params)
         ensure_query_params(query, params)
@@ -740,6 +768,8 @@ class DocumentQuerySet:
         params: QueryParams | None,
         **kwargs: Any,
     ) -> Any:
+        if current_listener() is None:
+            return NOOP_OBSERVE
         return observe(
             kind=kind,
             document=self.document_cls.__name__,
@@ -760,6 +790,8 @@ class DocumentQuerySet:
 
 
 def _observe_key(document_cls: type[Document], key: str, command: str) -> Any:
+    if current_listener() is None:
+        return NOOP_OBSERVE
     return observe(
         kind="get",
         document=document_cls.__name__,
@@ -796,14 +828,23 @@ def _single_hit(document_cls: type[Document], result: SearchResult) -> SearchHit
     return result.hits[0]
 
 
-def _text_lookups(document_cls: type[Document], prefix: str = "") -> list[str]:
+def _text_lookups(document_cls: type[Document]) -> list[str]:
+    cached = document_cls.__dict__.get(_TEXT_LOOKUPS_ATTR)
+    if isinstance(cached, list):
+        return cached
+    names = _collect_text_lookups(document_cls, "")
+    setattr(document_cls, _TEXT_LOOKUPS_ATTR, names)
+    return names
+
+
+def _collect_text_lookups(document_cls: type[Document], prefix: str) -> list[str]:
     names: list[str] = []
     for name, field in document_cls._meta.fields.items():
         path = f"{prefix}__{name}" if prefix else name
         if isinstance(field, Text):
             names.append(path)
         elif isinstance(field, (Object, Nested)):
-            names.extend(_text_lookups(field.target, path))
+            names.extend(_collect_text_lookups(field.target, path))
     return names
 
 
@@ -852,20 +893,34 @@ def _knn_blob(
     )
 
 
-def _iter_hash_vectors(
-    document_cls: type[Document], parent: str = ""
+def _iter_hash_vectors(document_cls: type[Document]) -> list[tuple[str, Vector]]:
+    cached = document_cls.__dict__.get(_HASH_VECTORS_ATTR)
+    if isinstance(cached, list):
+        return cached
+    found = _collect_hash_vectors(document_cls, "")
+    setattr(document_cls, _HASH_VECTORS_ATTR, found)
+    return found
+
+
+def _collect_hash_vectors(
+    document_cls: type[Document], parent: str
 ) -> list[tuple[str, Vector]]:
     found: list[tuple[str, Vector]] = []
     for field in document_cls._meta.fields.values():
         if isinstance(field, Vector):
             found.append((field.hash_name(parent), field))
         elif isinstance(field, Object):
-            found.extend(_iter_hash_vectors(field.target, field.hash_name(parent)))
+            found.extend(_collect_hash_vectors(field.target, field.hash_name(parent)))
     return found
 
 
 def _has_vector(document_cls: type[Document]) -> bool:
-    return bool(_iter_hash_vectors(document_cls))
+    cached = document_cls.__dict__.get(_HAS_VECTOR_ATTR)
+    if isinstance(cached, bool):
+        return cached
+    found = bool(_iter_hash_vectors(document_cls))
+    setattr(document_cls, _HAS_VECTOR_ATTR, found)
+    return found
 
 
 def _maybe_decode(value: str | bytes) -> str:

--- a/redis_search_django/schema.py
+++ b/redis_search_django/schema.py
@@ -12,6 +12,7 @@ from .enums import Storage
 from .fields import Field, Nested, Object, Tag, Vector
 
 _SCHEMA_CACHE_ATTR = "_rsd_schema_cache"
+_LOOKUP_CACHE_ATTR = "_rsd_lookup_cache"
 
 
 @dataclass(frozen=True)
@@ -253,6 +254,19 @@ def _redis_fields_for(
 
 def flatten_lookup(document_cls: type[Document], lookup: str) -> tuple[str, Field]:
     """Resolve a Django-style lookup path to (alias, leaf field)."""
+    cache = document_cls.__dict__.get(_LOOKUP_CACHE_ATTR)
+    if cache is None:
+        cache = {}
+        setattr(document_cls, _LOOKUP_CACHE_ATTR, cache)
+    cached = cache.get(lookup)
+    if cached is not None:
+        return cast(tuple[str, Field], cached)
+    resolved = _flatten_lookup(document_cls, lookup)
+    cache[lookup] = resolved
+    return resolved
+
+
+def _flatten_lookup(document_cls: type[Document], lookup: str) -> tuple[str, Field]:
     parts = [part for part in lookup.split("__") if part]
     parent_alias = ""
     current_doc = document_cls

--- a/redis_search_django/views.py
+++ b/redis_search_django/views.py
@@ -49,7 +49,12 @@ class SearchListViewMixin(MultipleObjectTemplateResponseMixin, _MultipleObjectMi
         return self.document_class.objects.all()
 
     def get_queryset(self) -> Any:
-        return self.get_search_queryset()
+        cached = getattr(self, "_search_qs", None)
+        if cached is not None:
+            return cached
+        qs = self.get_search_queryset()
+        self._search_qs = qs
+        return qs
 
     def facets(self) -> FacetMap | None:
         return None
@@ -97,6 +102,47 @@ class SearchListViewMixin(MultipleObjectTemplateResponseMixin, _MultipleObjectMi
         ):
             context["object_list"] = object_list.to_queryset()
         return context
+
+    def paginate_queryset(
+        self, queryset: Any, page_size: int
+    ) -> tuple[Any, Any, Any, bool]:
+        """One FT.SEARCH for the page: reuse ``total`` instead of a second COUNT."""
+        if not hasattr(queryset, "_search"):
+            return super().paginate_queryset(queryset, page_size)
+        paginator = self.get_paginator(
+            queryset,
+            page_size,
+            orphans=self.get_paginate_orphans(),
+            allow_empty_first_page=self.get_allow_empty(),
+        )
+        page_number = self._page_number(paginator, queryset)
+        offset = max((page_number - 1) * page_size, 0)
+        result = queryset._search(offset=offset, limit=page_size)
+        queryset._result = result
+        queryset._total = result.total
+        paginator.count = result.total
+        try:
+            page_obj = paginator.page(page_number)
+        except InvalidPage as exc:
+            raise Http404(f"Invalid page ({page_number}): {exc}") from exc
+        sliced: Any = page_obj.object_list
+        sliced._result = result
+        sliced._total = result.total
+        sliced._compiled = queryset._compiled
+        return paginator, page_obj, sliced, page_obj.has_other_pages()
+
+    def _page_number(self, paginator: Any, queryset: Any) -> int:
+        page_kwarg = self.page_kwarg
+        raw_page = self.kwargs.get(page_kwarg) or self.request.GET.get(page_kwarg) or 1
+        if raw_page == "last":
+            paginator.count = queryset.count()
+            return int(paginator.num_pages)
+        try:
+            return int(raw_page)
+        except ValueError:
+            raise Http404(
+                'Page is not "last", nor can it be converted to an int.'
+            ) from None
 
     def get(self, request: HttpRequest, *args: str, **kwargs: str) -> HttpResponse:
         self.object_list = self.get_queryset()
@@ -158,24 +204,36 @@ class SearchListViewMixin(MultipleObjectTemplateResponseMixin, _MultipleObjectMi
             orphans=self.get_paginate_orphans(),
             allow_empty_first_page=self.get_allow_empty(),
         )
-        if hasattr(queryset, "acount"):
-            paginator.count = await queryset.acount()
         page_kwarg = self.page_kwarg
         raw_page = self.kwargs.get(page_kwarg) or self.request.GET.get(page_kwarg) or 1
-        try:
-            page_number = int(raw_page)
-        except ValueError:
-            if raw_page == "last":
-                page_number = paginator.num_pages
-            else:
+        if raw_page == "last":
+            if hasattr(queryset, "acount"):
+                paginator.count = await queryset.acount()
+            page_number = paginator.num_pages
+        else:
+            try:
+                page_number = int(raw_page)
+            except ValueError:
                 raise Http404(
                     'Page is not "last", nor can it be converted to an int.'
                 ) from None
+        if hasattr(queryset, "_asearch"):
+            offset = (page_number - 1) * page_size
+            result = await queryset._asearch(offset=max(offset, 0), limit=page_size)
+            queryset._result = result
+            queryset._total = result.total
+            paginator.count = result.total
         try:
             page_obj = paginator.page(page_number)
         except InvalidPage as exc:
             raise Http404(f"Invalid page ({page_number}): {exc}") from exc
-        object_list = await self._amaterialize(page_obj.object_list)
+        object_list: Any = page_obj.object_list
+        cached = getattr(queryset, "_result", None)
+        if hasattr(object_list, "_result") and cached is not None:
+            object_list._result = cached
+            object_list._total = getattr(queryset, "_total", None)
+            object_list._compiled = getattr(queryset, "_compiled", None)
+        object_list = await self._amaterialize(object_list)
         page_obj.object_list = object_list
         return paginator, page_obj, object_list, page_obj.has_other_pages()
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -228,6 +228,8 @@ def test_tag_startswith_requires_suffix_trie():
 def test_escape_text_and_tag():
     assert "\\|" in escape_text("a|b")
     assert "\\ " in escape_tag("hello world")
+    assert "\\|" in escape_tag("a|b", separator="|")
+    assert "\\|" in escape_tag("c|d", separator="|")
 
 
 def test_query_too_long(document_class):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -610,6 +610,8 @@ def test_schema_weight_vector_and_flatten_lookup_error(document_class):
     name_field = Weighted._meta.fields["name"]
     assert name_field.weight == 2.0
     assert name_field.no_stem is True
+    assert flatten_lookup(Weighted, "name")[0] == "name"
+    assert flatten_lookup(Weighted, "name")[0] == "name"
     with pytest.raises(KeyError):
         flatten_lookup(Weighted, "missing")
     with pytest.raises(KeyError):

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -309,6 +309,22 @@ def _fake_search_client(total=0, docs=None, plan="INTERSECT {}", rows=None):
     return client, ft
 
 
+def test_observed_search_records_sort_label(document_class, monkeypatch):
+    from redis_search_django.query import queryset as qs_mod
+
+    doc = document_class("CatSortObs", Category, ["name"])
+    client, _ft = _fake_search_client(total=1)
+    monkeypatch.setattr(qs_mod, "get_redis_connection", lambda: client)
+    with capture_queries() as collector:
+        doc.objects.filter(name="X").count()
+        doc.objects.order_by("name").count()
+        doc.objects.order_by("-name").count()
+    sorts = [event.sort for event in collector.events if event.kind == "search"]
+    assert None in sorts
+    assert "name" in sorts
+    assert "-name" in sorts
+
+
 def test_search_and_explain_are_recorded(document_class, monkeypatch):
     from redis_search_django.query import queryset as qs_mod
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -73,9 +73,54 @@ def test_knn_requires_vector_field(document_class):
 def test_raw_and_search_clone(document_class):
     doc = document_class("CatRaw", Category, ["name"])
     qs = doc.objects.search("trail")
+    doc.objects.search("trail")
     query, params = qs.raw()
+    again, again_params = qs.raw()
     assert "name" in query
     assert params
+    assert again == query
+    assert again_params == params
+
+
+def test_exists_reuses_count_total(document_class):
+    doc = document_class("CatCountThenExists", Category, ["name"])
+    qs = doc.objects.filter(name="x")
+    qs._total = 3
+    assert qs.count() == 3
+    assert qs.exists() is True
+
+
+def test_count_and_exists_reuse_evaluated_result(document_class):
+    doc = document_class("CatCachedCount", Category, ["name"])
+    qs = doc.objects.filter(name="x")
+    qs._result = SearchResult(hits=[SearchHit(pk="1")], total=7, document_cls=doc)
+    assert qs.count() == 7
+    assert qs.exists() is True
+    assert len(qs) == 7
+    empty = doc.objects.filter(name="y")
+    empty._result = SearchResult(hits=[], total=0, document_cls=doc)
+    assert empty.count() == 0
+    assert empty.exists() is False
+
+
+async def test_aexists_reuses_acount_total(document_class):
+    doc = document_class("CatACountThenExists", Category, ["name"])
+    qs = doc.objects.filter(name="x")
+    qs._total = 2
+    assert await qs.acount() == 2
+    assert await qs.aexists() is True
+
+
+async def test_acount_and_aexists_reuse_evaluated_result(document_class):
+    doc = document_class("CatCachedACount", Category, ["name"])
+    qs = doc.objects.filter(name="x")
+    qs._result = SearchResult(hits=[SearchHit(pk="1")], total=4, document_cls=doc)
+    assert await qs.acount() == 4
+    assert await qs.aexists() is True
+    empty = doc.objects.filter(name="y")
+    empty._result = SearchResult(hits=[], total=0, document_cls=doc)
+    assert await empty.acount() == 0
+    assert await empty.aexists() is False
 
 
 def test_param_names_and_ensure_query_params():

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -362,6 +362,15 @@ def test_vector_source_typo_raises(category_obj):
 
     assert omitted.prepare(NoAttr(), Typo) is None
 
+    short = Vector(dims=4, source="name")
+    short.bind("embedding", Typo)
+
+    class NumericName:
+        name = [1.0, 2.0]
+
+    with pytest.raises(ConfigurationError, match="dimensions"):
+        short.prepare(NumericName(), Typo)
+
 
 def test_vector_to_index_value_json_hash_and_blob():
     field = Vector(dims=2, type="FLOAT32")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -11,7 +11,7 @@ from redis_search_django.indexer import Indexer
 from redis_search_django.query.queryset import DocumentQuerySet
 from redis_search_django.views import SearchListViewMixin
 
-from .helpers import alive_index
+from .helpers import alive_index, live_index
 from .models import Category
 
 
@@ -30,6 +30,58 @@ def test_get_search_queryset_defaults_to_all(document_class):
     qs = View().get_search_queryset()
     assert qs.document_cls is doc
     assert qs._none is False
+
+
+@pytest.mark.django_db
+def test_paginate_falls_back_for_orm_queryset(document_class):
+    Category.objects.create(name="orm-a")
+    Category.objects.create(name="orm-b")
+    doc = document_class("CategoryDocument", Category, ["name"])
+
+    class View(SearchListViewMixin, ListView):
+        document_class = doc
+        paginate_by = 1
+
+        def get_search_queryset(self):
+            return Category.objects.order_by("name")
+
+        def render_to_response(self, context, **response_kwargs):
+            assert context["paginator"].count == 2
+            return HttpResponse("ok")
+
+    assert View.as_view()(RequestFactory().get("/")).status_code == 200
+
+
+async def test_async_last_page_without_acount(document_class):
+    doc = document_class("CategoryDocument", Category, ["name"])
+
+    class View(SearchListViewMixin, ListView):
+        document_class = doc
+        paginate_by = 2
+        convert_to_queryset = False
+
+        async def get(self, request, *args, **kwargs):
+            return await self.aget(request, *args, **kwargs)
+
+        def get_search_queryset(self):
+            return ["a", "b", "c"]
+
+        def render_to_response(self, context, **response_kwargs):
+            assert context["page_obj"].number == 2
+            return HttpResponse("ok")
+
+    response = await View.as_view()(RequestFactory().get("/", {"page": "last"}))
+    assert response.status_code == 200
+
+
+def test_get_queryset_is_cached_for_the_request(document_class):
+    doc = document_class("CategoryDocument", Category, ["name"])
+
+    class View(SearchListViewMixin):
+        document_class = doc
+
+    view = View()
+    assert view.get_queryset() is view.get_queryset()
 
 
 def test_template_and_context_names(document_class):
@@ -110,6 +162,46 @@ async def test_async_get_renders_with_facets(document_class):
     response = await View.as_view()(request)
     assert response.status_code == 200
     assert response.content == b"ok"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_sync_view_paginates_and_rejects_bad_pages(document_class):
+    names = ["sync-a", "sync-b", "sync-c", "sync-d", "sync-e"]
+    for name in names:
+        Category.objects.create(name=name)
+    doc = document_class("CategoryDocument", Category, ["name"])
+    captured: dict = {}
+
+    class View(SearchListViewMixin, ListView):
+        document_class = doc
+        paginate_by = 2
+        convert_to_queryset = False
+
+        def get_search_queryset(self):
+            return doc.objects.order_by("name")
+
+        def render_to_response(self, context, **response_kwargs):
+            captured.clear()
+            captured.update(context)
+            return HttpResponse("ok")
+
+    with live_index(doc):
+        Indexer().upsert_queryset(doc, Category.objects.all())
+        response = View.as_view()(RequestFactory().get("/"))
+        assert response.status_code == 200
+        assert captured["is_paginated"] is True
+        assert captured["paginator"].count == 5
+        assert [hit.name for hit in captured["object_list"]] == ["sync-a", "sync-b"]
+
+        last = View.as_view()(RequestFactory().get("/", {"page": "last"}))
+        assert last.status_code == 200
+        assert captured["page_obj"].number == 3
+        assert [hit.name for hit in captured["object_list"]] == ["sync-e"]
+
+        with pytest.raises(Http404, match='not "last"'):
+            View.as_view()(RequestFactory().get("/", {"page": "abc"}))
+        with pytest.raises(Http404, match="Invalid page"):
+            View.as_view()(RequestFactory().get("/", {"page": "99"}))
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Cache compiled RediSearch strings, field lookups, prepare hooks, and the per-request search queryset. Skip debug observation when no listener is installed. Paginate with one FT.SEARCH (reuse total instead of a separate COUNT). Reuse that page total for unfiltered demo redis_count.